### PR TITLE
fix(summary): summary page questions now link back to the step

### DIFF
--- a/src/components/pages/SummaryPage.tsx
+++ b/src/components/pages/SummaryPage.tsx
@@ -1,19 +1,29 @@
+import { Button }     from '@trussworks/react-uswds';
 import { ReactNode }  from 'react';
+import { IQuestion }  from '../../survey';
 import { noel }       from '../../lib/noop';
 import { IPageData }  from '../../survey/IPageData';
 import { StepLayout } from '../wizard/StepLayout';
+import { Steps }      from '../lib';
 
 /**
  * Internal method to generate a list of the survey answers
  * @param props
  * @returns
  */
-const getAnswers = (props: IPageData): ReactNode => {
+const getAnswers = (props: IPageData, onClick: (question: IQuestion) => void): ReactNode => {
   const answers = props.form.responses.map((question) => (
       <li key={question.id} className="padding-bottom-2">
         <span className="text-light">
-          {question.title}:&nbsp;&nbsp;
-          <b>{question.answer}</b>
+          <Button
+            type="button"
+            unstyled
+            onClick={() => onClick(question)}
+          >
+            {question.title}
+          </Button>
+          :&nbsp;&nbsp;
+          <span className="text-bold">{question.answer}</span>
         </span>
       </li>
   ));
@@ -28,9 +38,14 @@ const getAnswers = (props: IPageData): ReactNode => {
  */
 export const SummaryPage = (props: IPageData): JSX.Element => {
   const { step: page } = props;
+
   if (!page) {
     return noel();
   }
 
-  return <StepLayout {...props}>{getAnswers(props)}</StepLayout>;
+  const onClick = (question: IQuestion) => {
+    Steps.goToStep(question.id, props);
+  };
+
+  return <StepLayout {...props}>{getAnswers(props, onClick)}</StepLayout>;
 };


### PR DESCRIPTION
fixes #65

- generates a link for each question on the summary page
- clicking the link navigates the user back to that question
