### PR TITLE
make progress bar work for simple flow as well as branch flow

### DIFF
--- a/src/composable/Questionnaire.ts
+++ b/src/composable/Questionnaire.ts
@@ -220,7 +220,8 @@ export class Questionnaire implements IQuestionnaire {
       return 101;
     }
 
-    const answerable = this.getBranchQuestions(props);
+    // if we have branches then we need to do this, otherwise we need to get the number of steps
+    const answerable = this.getAllAnswerableQuestions(props);
     const lastStep   = answerable.length; // sections[sections.length - 1]?.lastStep;
 
     // if there is no step, the questionnaire has just started
@@ -236,26 +237,56 @@ export class Questionnaire implements IQuestionnaire {
     }
     // To calculate the percent, divide the index of this step
     //   by the index of the last step multiplied by 100.
+
     return Math.round((thisStepIdx / lastStepIdx) * 100);
   }
 
   /**
    * Gets all of the questions associated with a branch
    * @param props
-   * @returns
+   * @returns string[]
    */
-  getBranchQuestions(props: IStepData): string[] {
+  getAllAnswerableQuestions(props: IStepData): string[] {
     const stepId = `${props.stepId}`;
     const step   = this.getStepById(stepId);
     if (!isEnum(QUESTION_TYPE, step.type)) {
       return [];
     }
+
+    if (this.branches.length) {
+      const question = step as IQuestion;
+      return this.getBranchQuestions(question);
+    } else {
+      return this.getQuestionsWithoutBranches();
+    }
+
+  }
+
+  /**
+   * Gets all of the questions associated with a branch
+   * @param step
+   * @returns string[]
+   */
+  private getBranchQuestions(step: IQuestion): string[] {
     const question = step as IQuestion;
+
     return (
       this.branches
         .find((b) => b.id === question.branch?.id)
         ?.questions.map((q) => q.id) || []
     );
+  }
+
+  /**
+   * Gets all of the questions regardless of branch
+   * @returns string[]
+   */
+  private getQuestionsWithoutBranches(): string[] {
+    return (
+      this.steps
+        .filter((q) => isEnum(QUESTION_TYPE, q.type))
+        .map(q => q.id)
+    )
   }
 
   /**


### PR DESCRIPTION
# Story Reference

This fixes an issue I found when I tried out the "simple flow" and noticed that the progress bar didn't move until the very end.

## Summary

Looks like when you added branching, the progress bar got switched to counting branch questions. Yet branches remained optional for questions. That made the progress bar always think it was on the first step until it was on the last. The proposed change checks to see whether there are branches. If there are, then it uses the existing behavior. If not, then it counts up the number of questions.

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
